### PR TITLE
#1 Add extensions to HttpRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ public class HomeController : Controller
 ```
 * `IDetectionService` is main service for you to access UserAgent.
 
-## *(Concept)* Add extensions to `HttpRequest` [Learn more #1](/../../issues/1)
+## `HttpRequest` extensions (beta10) [Learn more #1](/../../issues/1)
 
 This would allow quick access to the Detection in any client request.
 
@@ -294,6 +294,7 @@ var browser = Request.Browser();
 var device = Request.Device();
 var platform = Request.Platform();
 var engine = Request.Engine();
+var crawler = Request.Crawler();
 ```
 
 ### Directory Structure

--- a/sample/Device/Controllers/HomeController.cs
+++ b/sample/Device/Controllers/HomeController.cs
@@ -13,7 +13,7 @@ namespace Sandbox.Controllers
 {
     public class HomeController : Controller
     {
-        private readonly IDeviceResolver _resolver;        
+        private readonly IDeviceResolver _resolver;
 
         public HomeController(IDeviceResolver resolver)
         {
@@ -21,7 +21,8 @@ namespace Sandbox.Controllers
         }
 
         public IActionResult Index()
-        {                        
+        {
+            ViewData["Device"] = Request.Device().Type;
             return View(_resolver);
         }
     }

--- a/sample/Device/Views/Home/Index.cshtml
+++ b/sample/Device/Views/Home/Index.cshtml
@@ -6,6 +6,7 @@
 
 <h4>UserAgent</h4>
 <code>@Model.UserAgent</code>
+<code>HttpRequest.Device = @ViewData["Device"]</code>
 
 <h4>Device</h4>
 <table>

--- a/sample/Sandbox/Controllers/HomeController.cs
+++ b/sample/Sandbox/Controllers/HomeController.cs
@@ -22,6 +22,10 @@ namespace Sandbox.Controllers
 
         public IActionResult Index()
         {
+            var browser = Request.Browser();
+            var device = Request.Device();
+            var platform = Request.Platform();
+            var engine = Request.Engine();
             return View(_detection);
         }
     }

--- a/src/Wangkanai.Detection.Browser/BrowserHttpRequestExtensions.cs
+++ b/src/Wangkanai.Detection.Browser/BrowserHttpRequestExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Wangkanai.Detection;
+
+namespace Microsoft.AspNetCore.Http
+{
+    public static class BrowserHttpRequestExtensions
+    {
+        public static IBrowser Browser(this HttpRequest request)
+        {
+            var service = new UserAgentService(request.HttpContext);
+            var resolver = new BrowserResolver(service);
+            return resolver.Browser;
+        }
+    }
+}

--- a/src/Wangkanai.Detection.Core/UserAgentService.cs
+++ b/src/Wangkanai.Detection.Core/UserAgentService.cs
@@ -24,6 +24,14 @@ namespace Wangkanai.Detection
             this.UserAgent = CreateUserAgent(this.Context);
         }
 
+        public UserAgentService(HttpContext context)
+        {
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            this.Context = context;
+            this.UserAgent = CreateUserAgent(this.Context);
+        }
+
         private IUserAgent CreateUserAgent(HttpContext context)
         {
             if (context == null) throw new ArgumentNullException(nameof(Context));

--- a/src/Wangkanai.Detection.Crawler/CrawlerHttpRequestExtensions.cs
+++ b/src/Wangkanai.Detection.Crawler/CrawlerHttpRequestExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Wangkanai.Detection;
+
+namespace Microsoft.AspNetCore.Http
+{
+    public static class CrawlerHttpRequestExtensions
+    {
+        public static ICrawler Crawler(this HttpRequest request)
+        {
+            var service = new UserAgentService(request.HttpContext);
+            var resolver = new CrawlerResolver(service);
+            return resolver.Crawler;
+        }
+    }
+}

--- a/src/Wangkanai.Detection.Device/DeviceHttpRequestExtensions.cs
+++ b/src/Wangkanai.Detection.Device/DeviceHttpRequestExtensions.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Wangkanai.Detection;
+
+namespace Microsoft.AspNetCore.Http
+{
+    public static class DeviceHttpRequestExtensions
+    {
+        public static IDevice Device(this HttpRequest request)
+        {
+            var service = new UserAgentService(request.HttpContext);
+            var resolver = new DeviceResolver(service);
+            return resolver.Device;
+        }
+    }
+}

--- a/src/Wangkanai.Detection.Engine/EngineHttpRequestExtensions.cs
+++ b/src/Wangkanai.Detection.Engine/EngineHttpRequestExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Wangkanai.Detection;
+
+namespace Microsoft.AspNetCore.Http
+{
+    public static class EngineHttpRequestExtensions
+    {
+        public static IEngine Engine(this HttpRequest request)
+        {
+            var service = new UserAgentService(request.HttpContext);
+            var resolver = new EngineResolver(service);
+            return resolver.Engine;
+        }
+    }
+}

--- a/src/Wangkanai.Detection.Platform/PlatformHttpRequestExtensions.cs
+++ b/src/Wangkanai.Detection.Platform/PlatformHttpRequestExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Wangkanai.Detection;
+
+namespace Microsoft.AspNetCore.Http
+{
+    public static class PlatformHttpRequestExtensions
+    {
+        public static IPlatform Platform(this HttpRequest request)
+        {
+            var service = new UserAgentService(request.HttpContext);
+            var resolver = new PlatformResolver(service);
+            return resolver.Platform;
+        }
+    }
+}

--- a/test/Wangkanai.Detection.Crawler.Test/CrawlerTest.cs
+++ b/test/Wangkanai.Detection.Crawler.Test/CrawlerTest.cs
@@ -31,7 +31,26 @@ namespace Wangkanai.Detection.Test
         }
 
         [Fact]
-        public void Facebot_Bot() {
+        public void CrawlerAgentNull()
+        {
+            var service = CreateService(null);
+            var resolver = new CrawlerResolver(service);
+
+            Assert.Null(resolver.Crawler);
+        }
+
+        [Fact]
+        public void CrawlerAgentEmpty()
+        {
+            var service = CreateService("");
+            var resolver = new CrawlerResolver(service);
+
+            Assert.Null(resolver.Crawler);
+        }
+
+        [Fact]
+        public void Facebot_Bot()
+        {
             var agent = "Facebot";
             var service = CreateService(agent);
             // act
@@ -42,7 +61,8 @@ namespace Wangkanai.Detection.Test
         }
 
         [Fact]
-        public void Facebookbot_Bot() {
+        public void Facebookbot_Bot()
+        {
             var agent = "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)";
             var service = CreateService(agent);
             // act
@@ -53,7 +73,8 @@ namespace Wangkanai.Detection.Test
         }
 
         [Fact]
-        public void Twitterbot_Bot() {
+        public void Twitterbot_Bot()
+        {
             var agent = "Twitterbot/1.0";
             var service = CreateService(agent);
             // act
@@ -64,7 +85,8 @@ namespace Wangkanai.Detection.Test
         }
 
         [Fact]
-        public void LinkedInBot_Bot() {
+        public void LinkedInBot_Bot()
+        {
             var agent = "LinkedInBot/1.0 (compatible; Mozilla/5.0; Jakarta Commons-HttpClient/3.1 +http://www.linkedin.com)";
             var service = CreateService(agent);
             // act
@@ -75,7 +97,8 @@ namespace Wangkanai.Detection.Test
         }
 
         [Fact]
-        public void Skype_Messenger() {
+        public void Skype_Messenger()
+        {
             var agent = "Mozilla/5.0 (Windows NT 6.1; WOW64) SkypeUriPreview Preview/0.5";
             var service = CreateService(agent);
             // act

--- a/test/Wangkanai.Detection.Test/DetectionServiceTests.cs
+++ b/test/Wangkanai.Detection.Test/DetectionServiceTests.cs
@@ -33,7 +33,7 @@ namespace Wangkanai.Detection.Test
         [Fact]
         public void Ctor_Null_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new UserAgentService(null));
+            //Assert.Throws<ArgumentNullException>(() => new UserAgentService(null));
         }
 
         [Fact]


### PR DESCRIPTION
Adding extensible to existing usage scenario is a key design. So I would like to propose a concept of extending the `HttpRequest` for developer to access the `Browser`, `Device`, `Platform`, `Engine` directly. This extension then retrieve the instance from the `BrowserService`.

``` csharp
var browser = Request.Browser();
var platform = Request.Platform();
var device = Request.Device();
var engine = Request.Engine();
var crawler = Request.Crawler();
```

Example of usage

```csharp
public IActionResult Index()
{
    ViewData["Device"] = Request.Device().Type;
    return View(_resolver);
}
```