### PR TITLE
Add detection for IE 11 on Windows 10

### DIFF
--- a/src/Detection.Browser/src/Collections/InternetExplorer.cs
+++ b/src/Detection.Browser/src/Collections/InternetExplorer.cs
@@ -24,7 +24,7 @@ namespace Wangkanai.Detection.Collections
                 Type = BrowserType.IE;
             }
 
-            if(_agent.Contains("ie 11.0"))
+            if (_agent.Contains("ie 11.0") || (_agent.Contains("trident/") && _agent.Contains("rv:11.0")))
             {
                 Type = BrowserType.IE;
                 Version = new Version("11.0");

--- a/src/Detection.Browser/test/BrowserResolverTests.cs
+++ b/src/Detection.Browser/test/BrowserResolverTests.cs
@@ -38,6 +38,7 @@ namespace Wangkanai.Detection.Test
         [Theory]
         [InlineData("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)")]
         [InlineData("Mozilla/5.0 (IE 11.0; Windows NT 6.3; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko")]
+        [InlineData("Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko")]
         public void Resolve_IE(string agent)
         {
             // arrange


### PR DESCRIPTION
Extend IE detection to resolve issue where IE11 on Windows 10 is detected as Generic.

Approach:
 - Check for "Trident/" and "rv:11.0" in the user agent string

Addresses #62 
