### PR TITLE
Remove depend on HttpContextExtensions

### DIFF
--- a/src/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/DependencyInjection/BuilderExtensions/Core.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IDetectionBuilder AddRequiredPlatformServices(this IDetectionBuilder builder)
         {
             // Hosting doesn't add IHttpContextAccessor by default
-            builder.Services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+            builder.Services.AddHttpContextAccessor();//.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
             // Add Detection Options
             builder.Services.AddOptions();

--- a/src/Extensions/EnumerableExtensions.cs
+++ b/src/Extensions/EnumerableExtensions.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Wangkanai.Detection.Extensions
 {
-    internal static class IEnumerableExtensions
+    internal static class EnumerableExtensions
     {
         public static bool IsNullOrEmpty<T>(this IEnumerable<T> list)
             => list == null || !list.Any();

--- a/src/Extensions/VersionExtensions.cs
+++ b/src/Extensions/VersionExtensions.cs
@@ -21,13 +21,7 @@ namespace Wangkanai.Detection.Extensions
                 ? parsedVersion
                 : new Version(0, 0);
         }
-
-        /// <summary>
-        ///     if request is going via google proxy then version will be appended with Firefox/11.0 (via ggpht.com
-        ///     GoogleImageProxy)
-        /// </summary>
-        /// <param name="version"></param>
-        /// <returns></returns>
+        
         private static string RemoveWhitespace(this string version)
             => version.Contains(" ") ? version.Replace(" ", "") : version;
 

--- a/src/Services/PreferenceService.cs
+++ b/src/Services/PreferenceService.cs
@@ -1,27 +1,29 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Wangkanai.Detection.Models;
 
 namespace Wangkanai.Detection.Services
 {
     public class PreferenceService : IPreferenceService
     {
-        private readonly IUserAgentService _userAgentService;
+        private readonly HttpContext _context;
 
         public Device Preferred
         {
-            get => _userAgentService.Context.GetPreference();
-            private set => _userAgentService.Context.SetPreference(value);
+            get => _context.GetPreference();
+            private set => _context.SetPreference(value);
         }
 
         public bool IsSet
         {
-            get => _userAgentService.Context.GetMark();
-            private set => _userAgentService.Context.SetMark(value);
+            get => _context.GetMark();
+            private set => _context.SetMark(value);
         }
         
-        public PreferenceService(IUserAgentService userAgentService)
+        public PreferenceService(IHttpContextAccessor accessor)
         {
-            _userAgentService = userAgentService;
+            _context = accessor.HttpContext;
         }
 
         public void Set(Device preferred)

--- a/src/Services/UserAgentService.cs
+++ b/src/Services/UserAgentService.cs
@@ -14,15 +14,14 @@ namespace Wangkanai.Detection.Services
         public HttpContext Context   { get; }
         public UserAgent   UserAgent { get; }
 
-        public UserAgentService(IServiceProvider services)//, HttpContext context)
+        public UserAgentService(IHttpContextAccessor accessor)
         {
-            if (services == null)
-                throw new ArgumentNullException(nameof(services));
-
-            Context = services.GetRequiredService<IHttpContextAccessor>().HttpContext;
-
-            if (Context == null)
-                throw new ArgumentNullException(nameof(Context));
+            if (accessor == null) 
+                throw new ArgumentNullException(nameof(accessor));
+            if (accessor.HttpContext == null) 
+                throw new ArgumentNullException(nameof(accessor.HttpContext));
+            
+            Context = accessor.HttpContext;
 
             var agent = Context.Request.Headers["User-Agent"].FirstOrDefault();
             UserAgent = new UserAgent(agent);

--- a/test/Services/DetectionServiceTests.cs
+++ b/test/Services/DetectionServiceTests.cs
@@ -15,15 +15,10 @@ namespace Wangkanai.Detection.Services
             string userAgent = "Agent";
             var    context   = new DefaultHttpContext();
             context.Request.Headers["User-Agent"] = userAgent;
-            var serviceProvider = new ServiceProvider()
-            {
-                HttpContextAccessor = new HttpContextAccessor()
-                {
-                    HttpContext = context
-                }
-            };
 
-            var useragentService = new UserAgentService(serviceProvider);
+            var accessor = new HttpContextAccessor {HttpContext = context};
+
+            var useragentService = new UserAgentService(accessor);
 
             Assert.NotNull(useragentService.Context);
             Assert.NotNull(useragentService.UserAgent);
@@ -37,21 +32,18 @@ namespace Wangkanai.Detection.Services
         }
 
         [Fact]
-        public void Ctor_HttpContextAccessorNotResolved_ThrowsInvalidOperationException()
+        public void Ctor_HttpContextAccessorNotResolved_ThrowsArgumentNullException()
         {
-            Assert.Throws<InvalidOperationException>(() => new UserAgentService(new ServiceProvider()));
+            Assert.Throws<ArgumentNullException>(() => new UserAgentService(new HttpContextAccessor()));
         }
 
         [Fact]
         public void Ctor_HttpContextNull_ThrowsArgumentNullException()
         {
-            var serviceProvider = new ServiceProvider()
-            {
-                HttpContextAccessor = new HttpContextAccessor()
-            };
-
-            Assert.Null(serviceProvider.HttpContextAccessor.HttpContext);
-            Assert.Throws<ArgumentNullException>(() => new UserAgentService(serviceProvider));
+            var accessor = new HttpContextAccessor();
+            
+            Assert.Null(accessor.HttpContext);
+            Assert.Throws<ArgumentNullException>(() => new UserAgentService(accessor));
         }
 
         private class ServiceProvider : IServiceProvider


### PR DESCRIPTION
Also giving services with direct dependency injection of `HttpContextAccessor`. So their don't need to go through of UserAgentService every time.
