### PR TITLE
Resolver services determine the Name not the Type

### DIFF
--- a/sample/Detection/Pages/Index.cshtml
+++ b/sample/Detection/Pages/Index.cshtml
@@ -12,8 +12,8 @@
 
     <ul class="list-group flex-md-row">
         <li class="col-xs-12 col-sm-3 list-group-item list-group-item-success">@Detection.Device?.Type</li>
-        <li class="col-xs-12 col-sm-3 list-group-item list-group-item-danger">@Detection.Browser?.Type @Detection.Browser?.Version.Major</li>
-        <li class="col-xs-12 col-sm-3 list-group-item list-group-item-primary">@Detection.Platform?.OperatingSystem (@Detection.Platform?.Processor)</li>
-        <li class="col-xs-12 col-sm-3 list-group-item list-group-item-warning">@Detection.Engine?.Type</li>
+        <li class="col-xs-12 col-sm-3 list-group-item list-group-item-danger">@Detection.Browser?.Name @Detection.Browser?.Version.Major</li>
+        <li class="col-xs-12 col-sm-3 list-group-item list-group-item-primary">@Detection.Platform?.Name (@Detection.Platform?.Processor)</li>
+        <li class="col-xs-12 col-sm-3 list-group-item list-group-item-warning">@Detection.Engine?.Name</li>
     </ul>
 </div>

--- a/sample/DetectionOld/Views/Home/Index.cshtml
+++ b/sample/DetectionOld/Views/Home/Index.cshtml
@@ -25,22 +25,22 @@
         </tr>
         <tr>
             <th>Platform</th>
-            <td>@Model.Platform?.OperatingSystem</td>
+            <td>@Model.Platform?.Name</td>
             <td>@Model.Platform?.Processor</td>
         </tr>
         <tr>
             <th>Engine</th>
-            <td>@Model.Engine?.Type</td>
+            <td>@Model.Engine?.Name</td>
             <td></td>
         </tr>
         <tr>
             <th>Browser</th>
-            <td>@Model.Browser?.Type</td>
+            <td>@Model.Browser?.Name</td>
             <td>@Model.Browser?.Version</td>
         </tr>
         <tr>
             <th>Crawler</th>
-            <td>@Model.Crawler?.Type</td>
+            <td>@Model.Crawler?.Name</td>
             <td>@Model.Crawler?.Version</td>
         </tr>
     </tbody>

--- a/src/Services/BrowserService.cs
+++ b/src/Services/BrowserService.cs
@@ -10,16 +10,16 @@ namespace Wangkanai.Detection.Services
 {
     public class BrowserService : IBrowserService
     {
-        public Browser Type    { get; }
+        public Browser Name    { get; }
         public Version Version { get; }
 
         public BrowserService(IUserAgentService userAgentService, IPlatformService platformService, IEngineService engineService)
         {
             var agent  = userAgentService.UserAgent;
-            var os     = platformService.OperatingSystem;
-            var engine = engineService.Type;
-            Type    = GetBrowser(agent, os, engine);
-            Version = GetVersion(agent.ToLower(), Type.ToString());
+            var os     = platformService.Name;
+            var engine = engineService.Name;
+            Name    = GetBrowser(agent, os, engine);
+            Version = GetVersion(agent.ToLower(), Name.ToString());
         }
 
         private static Browser GetBrowser(UserAgent agent, OperatingSystem os, Engine engine)

--- a/src/Services/CrawlerService.cs
+++ b/src/Services/CrawlerService.cs
@@ -13,15 +13,15 @@ namespace Wangkanai.Detection.Services
     public class CrawlerService : ICrawlerService
     {
         public bool    IsCrawler { get; }
-        public Crawler Type      { get; }
+        public Crawler Name      { get; }
         public Version Version   { get; }
 
         public CrawlerService(IUserAgentService useragent, DetectionOptions options)
         {
             var agent = useragent.UserAgent;
 
-            Type      = GetCrawler(agent, options?.Crawler.Others);
-            IsCrawler = Type != Crawler.Unknown;
+            Name      = GetCrawler(agent, options?.Crawler.Others);
+            IsCrawler = Name != Crawler.Unknown;
             Version   = GetVersion(agent);
         }
 

--- a/src/Services/EngineService.cs
+++ b/src/Services/EngineService.cs
@@ -8,14 +8,14 @@ namespace Wangkanai.Detection.Services
 {
     public class EngineService : IEngineService
     {
-        public Engine Type { get; }
+        public Engine Name { get; }
 
         public EngineService(IUserAgentService userAgentService, IPlatformService platformService)
         {
             var agent = userAgentService.UserAgent;
-            var os    = platformService.OperatingSystem;
+            var os    = platformService.Name;
             var cpu   = platformService.Processor;
-            Type = ParseEngine(agent, os, cpu);
+            Name = ParseEngine(agent, os, cpu);
         }
 
         private static Engine ParseEngine(UserAgent agent, OperatingSystem os, Processor cpu)

--- a/src/Services/Interfaces/IBrowserService.cs
+++ b/src/Services/Interfaces/IBrowserService.cs
@@ -6,9 +6,19 @@ using Wangkanai.Detection.Models;
 
 namespace Wangkanai.Detection.Services
 {
+    /// <summary>
+    /// Provides the APIs for query client <see cref="Browser"/>.
+    /// </summary>
     public interface IBrowserService
     {
-        public Browser Type { get; }
+        /// <summary>
+        /// Gets the <see cref="Browser"/> name of the request client.
+        /// </summary>
+        public Browser Name { get; }
+        
+        /// <summary>
+        /// Gets the <see cref="Version"/> of the request client. 
+        /// </summary>
         public Version Version { get; }
     }
 }

--- a/src/Services/Interfaces/ICrawlerService.cs
+++ b/src/Services/Interfaces/ICrawlerService.cs
@@ -6,10 +6,24 @@ using Wangkanai.Detection.Models;
 
 namespace Wangkanai.Detection.Services
 {
+    /// <summary>
+    /// Provides the APIs for query <see cref="Crawler"/>.
+    /// </summary>
     public interface ICrawlerService
     {
+        /// <summary>
+        /// Determine that the request client is crawler.
+        /// </summary>
         public bool IsCrawler { get; }
-        public Crawler Type { get; }
+        
+        /// <summary>
+        /// Gets the <see cref="Crawler"/> name of the request clients.
+        /// </summary>
+        public Crawler Name { get; }
+        
+        /// <summary>
+        /// Gets the <see cref="Version"/> of the request client.
+        /// </summary>
         public Version Version { get; }
     }
 }

--- a/src/Services/Interfaces/IDetectionService.cs
+++ b/src/Services/Interfaces/IDetectionService.cs
@@ -5,13 +5,39 @@ using Wangkanai.Detection.Models;
 
 namespace Wangkanai.Detection.Services
 {
+    /// <summary>
+    /// Provides the APIs for query client detection services.
+    /// </summary>
     public interface IDetectionService
     {
+        /// <summary>
+        /// Get the <see cref="UserAgent"/> of the request client.
+        /// </summary>
         public UserAgent UserAgent { get; }
+        
+        /// <summary>
+        /// Get the <see cref="Device"/> resolved of the request client. 
+        /// </summary>
         public IDeviceService Device { get; }
-        public ICrawlerService Crawler { get; }
+
+        /// <summary>
+        /// Get the <see cref="Platform"/> resolved of the request client. 
+        /// </summary>
         public IPlatformService Platform { get; }
+        
+        /// <summary>
+        /// Get the <see cref="Engine"/> resolved of the request client. 
+        /// </summary>
         public IEngineService Engine { get; }
+        
+        /// <summary>
+        /// Get the <see cref="Browser"/> resolved of the request client. 
+        /// </summary>
         public IBrowserService Browser { get; }
+
+        /// <summary>
+        /// Get the <see cref="Crawler"/> resolved of the request client. 
+        /// </summary>
+        public ICrawlerService Crawler { get; }
     }
 }

--- a/src/Services/Interfaces/IDeviceService.cs
+++ b/src/Services/Interfaces/IDeviceService.cs
@@ -5,8 +5,14 @@ using Wangkanai.Detection.Models;
 
 namespace Wangkanai.Detection.Services
 {
+    /// <summary>
+    /// Provides the APIs for query client <see cref="Device"/>.
+    /// </summary>
     public interface IDeviceService
     {
+        /// <summary>
+        /// Gets the <see cref="Device"/> of the request client.
+        /// </summary>
         public Device Type { get; }
     }
 }

--- a/src/Services/Interfaces/IEngineService.cs
+++ b/src/Services/Interfaces/IEngineService.cs
@@ -5,8 +5,14 @@ using Wangkanai.Detection.Models;
 
 namespace Wangkanai.Detection.Services
 {
+    /// <summary>
+    /// Provides the APIs for query client browser rendering engine.
+    /// </summary>
     public interface IEngineService
     {
-        public Engine Type { get; }
+        /// <summary>
+        /// Get the <see cref="Engine"/> of the request client.
+        /// </summary>
+        public Engine Name { get; }
     }
 }

--- a/src/Services/Interfaces/IPlatformService.cs
+++ b/src/Services/Interfaces/IPlatformService.cs
@@ -5,9 +5,19 @@ using Wangkanai.Detection.Models;
 
 namespace Wangkanai.Detection.Services
 {
+    /// <summary>
+    /// Provides the APIs for query client platform.
+    /// </summary>
     public interface IPlatformService
     {
+        /// <summary>
+        /// Gets the <see cref="Processor"/> of the request client.
+        /// </summary>
         public Processor Processor { get; }
-        public OperatingSystem OperatingSystem { get; }
+        
+        /// <summary>
+        /// Gets the <see cref="OperatingSystem"/> of the request client.
+        /// </summary>
+        public OperatingSystem Name { get; }
     }
 }

--- a/src/Services/Interfaces/IUserAgentService.cs
+++ b/src/Services/Interfaces/IUserAgentService.cs
@@ -12,12 +12,12 @@ namespace Wangkanai.Detection.Services
     public interface IUserAgentService
     {
         /// <summary>
-        /// Get HttpContext of the application service
+        /// Get the <see cref="HttpContext"/> of the application service.
         /// </summary>
         HttpContext Context { get; }
 
         /// <summary>
-        /// Get user agnet of the request client
+        /// Get the <see cref="UserAgent"/> of the request client.
         /// </summary>
         UserAgent UserAgent { get; }
     }

--- a/src/Services/PlatformService.cs
+++ b/src/Services/PlatformService.cs
@@ -9,13 +9,13 @@ namespace Wangkanai.Detection.Services
     public class PlatformService : IPlatformService
     {
         public Processor       Processor       { get; }
-        public OperatingSystem OperatingSystem { get; }
+        public OperatingSystem Name { get; }
 
         public PlatformService(IUserAgentService userAgentService)
         {
             var userAgent = userAgentService.UserAgent;
-            OperatingSystem = ParseOperatingSystem(userAgent);
-            Processor       = ParseProcessor(userAgent, OperatingSystem);
+            Name = ParseOperatingSystem(userAgent);
+            Processor       = ParseProcessor(userAgent, Name);
         }
 
         private static OperatingSystem ParseOperatingSystem(UserAgent agent)

--- a/src/TagHelpers/BrowserTagHelper.cs
+++ b/src/TagHelpers/BrowserTagHelper.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             if (string.IsNullOrEmpty(Include) && string.IsNullOrEmpty(Exclude))
                 return;
 
-            var browser = _resolver.Type.ToString();
+            var browser = _resolver.Name.ToString();
 
             if (Exclude != null)
             {

--- a/src/TagHelpers/CrawlerTagHelper.cs
+++ b/src/TagHelpers/CrawlerTagHelper.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             if(!_resolver.IsCrawler)
                 return;
 
-            var crawler = _resolver.Type.ToString();
+            var crawler = _resolver.Name.ToString();
 
             if (Exclude != null)
             {

--- a/src/TagHelpers/EngineTagHelper.cs
+++ b/src/TagHelpers/EngineTagHelper.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             if (string.IsNullOrEmpty(Include) && string.IsNullOrEmpty(Exclude))
                 return;
             
-            var engine = _resolver.Type.ToString();
+            var engine = _resolver.Name.ToString();
 
             if (Exclude != null)
             {

--- a/src/TagHelpers/PlatformTagHelper.cs
+++ b/src/TagHelpers/PlatformTagHelper.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             if (string.IsNullOrEmpty(Include) && string.IsNullOrEmpty(Exclude))
                 return;
             
-            var platform = _resolver.OperatingSystem.ToString();
+            var platform = _resolver.Name.ToString();
 
             if (Exclude != null)
             {

--- a/test/Services/BrowserServiceTest.cs
+++ b/test/Services/BrowserServiceTest.cs
@@ -11,7 +11,7 @@ namespace Wangkanai.Detection.Services
         {
             var resolver = MockBrowserService(null);
             Assert.NotNull(resolver);
-            Assert.Equal(Browser.Unknown, resolver.Type);
+            Assert.Equal(Browser.Unknown, resolver.Name);
             Assert.Equal(new Version(0, 0), resolver.Version);
         }
 
@@ -20,7 +20,7 @@ namespace Wangkanai.Detection.Services
         {
             var resolver = MockBrowserService("");
             Assert.NotNull(resolver);
-            Assert.Equal(Browser.Unknown, resolver.Type);
+            Assert.Equal(Browser.Unknown, resolver.Name);
             Assert.Equal(new Version(0, 0), resolver.Version);
         }
 
@@ -31,7 +31,7 @@ namespace Wangkanai.Detection.Services
         public void Chrome(string version, string agent)
         {
             var resolver = MockBrowserService(agent);
-            Assert.Equal(Browser.Chrome, resolver.Type);
+            Assert.Equal(Browser.Chrome, resolver.Name);
             Assert.Equal(new Version(version), resolver.Version);
         }
 
@@ -43,7 +43,7 @@ namespace Wangkanai.Detection.Services
         public void InternetExplorer(string version, string agent)
         {
             var resolver = MockBrowserService(agent);
-            Assert.Equal(Browser.InternetExplorer, resolver.Type);
+            Assert.Equal(Browser.InternetExplorer, resolver.Name);
             Assert.Equal(new Version(version), resolver.Version);
         }
 
@@ -54,7 +54,7 @@ namespace Wangkanai.Detection.Services
         public void Safari(string agent)
         {
             var resolver = MockBrowserService(agent);
-            Assert.Equal(Browser.Safari, resolver.Type);
+            Assert.Equal(Browser.Safari, resolver.Name);
         }
 
         [Theory]
@@ -64,7 +64,7 @@ namespace Wangkanai.Detection.Services
         public void Firefox(string agent)
         {
             var resolver = MockBrowserService(agent);
-            Assert.Equal(Browser.Firefox, resolver.Type);
+            Assert.Equal(Browser.Firefox, resolver.Name);
         }
 
         [Theory]
@@ -75,7 +75,7 @@ namespace Wangkanai.Detection.Services
         public void Edge(string agent)
         {
             var resolver = MockBrowserService(agent);
-            Assert.Equal(Browser.Edge, resolver.Type);
+            Assert.Equal(Browser.Edge, resolver.Name);
         }
 
         [Theory]
@@ -86,7 +86,7 @@ namespace Wangkanai.Detection.Services
         public void Opera(string agent)
         {
             var resolver = MockBrowserService(agent);
-            Assert.Equal(Browser.Opera, resolver.Type);
+            Assert.Equal(Browser.Opera, resolver.Name);
         }
 
         [Theory]
@@ -94,7 +94,7 @@ namespace Wangkanai.Detection.Services
         public void Others(string agent)
         {
             var resolver = MockBrowserService(agent);
-            Assert.Equal(Browser.Others, resolver.Type);
+            Assert.Equal(Browser.Others, resolver.Name);
         }
 
         private static BrowserService MockBrowserService(string agent)

--- a/test/Services/CrawlerServiceTest.cs
+++ b/test/Services/CrawlerServiceTest.cs
@@ -17,7 +17,7 @@ namespace Wangkanai.Detection.Services
         {
             var resolver = MockService.CreateCrawlerService(null);
             Assert.NotNull(resolver);
-            Assert.Equal(Crawler.Unknown, resolver.Type);
+            Assert.Equal(Crawler.Unknown, resolver.Name);
         }
 
         [Fact]
@@ -26,7 +26,7 @@ namespace Wangkanai.Detection.Services
             var agent    = "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0";
             var resolver = MockService.CreateCrawlerService(agent);
             Assert.False(resolver.IsCrawler);
-            Assert.Equal(Crawler.Unknown, resolver.Type);
+            Assert.Equal(Crawler.Unknown, resolver.Name);
         }
 
         [Fact]
@@ -35,7 +35,7 @@ namespace Wangkanai.Detection.Services
             var agent   = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)";
             var crawler = MockService.CreateCrawlerService(agent);
             Assert.True(crawler.IsCrawler);
-            Assert.Equal(Crawler.Google, crawler.Type);
+            Assert.Equal(Crawler.Google, crawler.Name);
             Assert.Equal(new Version(2, 1), crawler.Version);
         }
 
@@ -45,7 +45,7 @@ namespace Wangkanai.Detection.Services
             var agent   = "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)";
             var crawler = MockService.CreateCrawlerService(agent);
             Assert.True(crawler.IsCrawler);
-            Assert.Equal(Crawler.Facebook, crawler.Type);
+            Assert.Equal(Crawler.Facebook, crawler.Name);
             Assert.Equal(new Version(1, 1), crawler.Version);
         }
 
@@ -55,7 +55,7 @@ namespace Wangkanai.Detection.Services
             var agent    = "Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)";
             var resolver = MockService.CreateCrawlerService(agent);
             Assert.True(resolver.IsCrawler);
-            Assert.Equal(Crawler.Bing, resolver.Type);
+            Assert.Equal(Crawler.Bing, resolver.Name);
             Assert.Equal(new Version(2, 0), resolver.Version);
         }
 
@@ -65,7 +65,7 @@ namespace Wangkanai.Detection.Services
             var agent    = "Twitterbot/1.0";
             var resolver = MockService.CreateCrawlerService(agent);
             Assert.True(resolver.IsCrawler);
-            Assert.Equal(Crawler.Twitter, resolver.Type);
+            Assert.Equal(Crawler.Twitter, resolver.Name);
             Assert.Equal(new Version(1, 0), resolver.Version);
         }
 
@@ -74,7 +74,7 @@ namespace Wangkanai.Detection.Services
         {
             var agent    = "Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)";
             var resolver = MockService.CreateCrawlerService(agent);
-            Assert.Equal(Crawler.Yahoo, resolver.Type);
+            Assert.Equal(Crawler.Yahoo, resolver.Name);
             Assert.Equal(new Version(), resolver.Version);
         }
 
@@ -84,7 +84,7 @@ namespace Wangkanai.Detection.Services
             var agent    = "Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)";
             var resolver = MockService.CreateCrawlerService(agent);
             Assert.True(resolver.IsCrawler);
-            Assert.Equal(Crawler.Baidu, resolver.Type);
+            Assert.Equal(Crawler.Baidu, resolver.Name);
             Assert.Equal(new Version(2, 0), resolver.Version);
         }
 
@@ -94,7 +94,7 @@ namespace Wangkanai.Detection.Services
             var agent    = "LinkedInBot/1.0 (compatible; Mozilla/5.0; Jakarta Commons-HttpClient/3.1 +http://www.linkedin.com)";
             var resolver = MockService.CreateCrawlerService(agent);
             Assert.True(resolver.IsCrawler);
-            Assert.Equal(Crawler.LinkedIn, resolver.Type);
+            Assert.Equal(Crawler.LinkedIn, resolver.Name);
             Assert.Equal(new Version(1, 0), resolver.Version);
         }
 
@@ -104,7 +104,7 @@ namespace Wangkanai.Detection.Services
             var agent    = "Mozilla/5.0 (Windows NT 6.1; WOW64) SkypeUriPreview Preview/0.5";
             var resolver = MockService.CreateCrawlerService(agent);
             Assert.True(resolver.IsCrawler);
-            Assert.Equal(Crawler.Skype, resolver.Type);
+            Assert.Equal(Crawler.Skype, resolver.Name);
         }
 
         [Fact]
@@ -113,7 +113,7 @@ namespace Wangkanai.Detection.Services
             var agent    = "WhatsApp/2.18.61 i";
             var resolver = MockService.CreateCrawlerService(agent);
             Assert.True(resolver.IsCrawler);
-            Assert.Equal(Crawler.WhatsApp, resolver.Type);
+            Assert.Equal(Crawler.WhatsApp, resolver.Name);
             Assert.Equal(new Version(2, 18, 61), resolver.Version);
         }
 
@@ -124,7 +124,7 @@ namespace Wangkanai.Detection.Services
         {
             var resolver = MockService.CreateCrawlerService(agent);
             Assert.True(resolver.IsCrawler);
-            Assert.Equal(Crawler.Others, resolver.Type);
+            Assert.Equal(Crawler.Others, resolver.Name);
         }
 
         [Fact]
@@ -135,7 +135,7 @@ namespace Wangkanai.Detection.Services
             options.Crawler.Others.Add("starnic");
             var resolver = MockService.CreateCrawlerService(agent, options);
             Assert.True(resolver.IsCrawler);
-            Assert.Equal(Crawler.Others, resolver.Type);
+            Assert.Equal(Crawler.Others, resolver.Name);
         }
     }
 }

--- a/test/Services/EngineServiceTest.cs
+++ b/test/Services/EngineServiceTest.cs
@@ -13,7 +13,7 @@ namespace Wangkanai.Detection.Services
         {
             var resolver = MockService.CreateEngineService(null);
             Assert.NotNull(resolver);
-            Assert.Equal(Engine.Unknown, resolver.Type);
+            Assert.Equal(Engine.Unknown, resolver.Name);
         }
 
         [Theory]
@@ -24,7 +24,7 @@ namespace Wangkanai.Detection.Services
         public void Trident(Engine engine, string agent)
         {
             var resolver = MockService.CreateEngineService(agent);
-            Assert.Equal(engine, resolver.Type);
+            Assert.Equal(engine, resolver.Name);
         }
 
 
@@ -35,7 +35,7 @@ namespace Wangkanai.Detection.Services
         public void WebKit(Engine engine, string agent)
         {
             var resolver = MockService.CreateEngineService(agent);
-            Assert.Equal(engine, resolver.Type);
+            Assert.Equal(engine, resolver.Name);
         }
 
         [Theory]
@@ -45,7 +45,7 @@ namespace Wangkanai.Detection.Services
         public void Blink(Engine engine, string agent)
         {
             var resolver = MockService.CreateEngineService(agent);
-            Assert.Equal(engine, resolver.Type);
+            Assert.Equal(engine, resolver.Name);
         }
 
         [Theory]
@@ -55,7 +55,7 @@ namespace Wangkanai.Detection.Services
         public void Gecko(Engine engine, string agent)
         {
             var resolver = MockService.CreateEngineService(agent);
-            Assert.Equal(engine, resolver.Type);
+            Assert.Equal(engine, resolver.Name);
         }
 
         [Theory]
@@ -66,7 +66,7 @@ namespace Wangkanai.Detection.Services
         public void Edge(Engine engine, string agent)
         {
             var resolver = MockService.CreateEngineService(agent);
-            Assert.Equal(engine, resolver.Type);
+            Assert.Equal(engine, resolver.Name);
         }
 
         [Theory]
@@ -76,7 +76,7 @@ namespace Wangkanai.Detection.Services
         public void Servo(Engine engine, string agent)
         {
             var resolver = MockService.CreateEngineService(agent);
-            Assert.Equal(engine, resolver.Type);
+            Assert.Equal(engine, resolver.Name);
         }
     }
 }

--- a/test/Services/PlatformServiceTest.cs
+++ b/test/Services/PlatformServiceTest.cs
@@ -13,7 +13,7 @@ namespace Wangkanai.Detection.Services
         {
             var resolver = MockService.CreatePlatformService(null);
             Assert.NotNull(resolver);
-            Assert.Equal(OperatingSystem.Unknown, resolver.OperatingSystem);
+            Assert.Equal(OperatingSystem.Unknown, resolver.Name);
             Assert.Equal(Processor.Others, resolver.Processor);
         }
 
@@ -26,7 +26,7 @@ namespace Wangkanai.Detection.Services
         {
             var os       = OperatingSystem.Windows;
             var resolver = MockService.CreatePlatformService(agent);
-            Assert.Equal(os, resolver.OperatingSystem);
+            Assert.Equal(os, resolver.Name);
             Assert.Equal(processor, resolver.Processor);
         }
 
@@ -39,7 +39,7 @@ namespace Wangkanai.Detection.Services
             var os        = OperatingSystem.Android;
             var processor = Processor.ARM;
             var resolver  = MockService.CreatePlatformService(agent);
-            Assert.Equal(os, resolver.OperatingSystem);
+            Assert.Equal(os, resolver.Name);
             Assert.Equal(processor, resolver.Processor);
         }
 
@@ -52,7 +52,7 @@ namespace Wangkanai.Detection.Services
             var os        = OperatingSystem.iOS;
             var processor = Processor.ARM;
             var resolver  = MockService.CreatePlatformService(agent);
-            Assert.Equal(os, resolver.OperatingSystem);
+            Assert.Equal(os, resolver.Name);
             Assert.Equal(processor, resolver.Processor);
         }
 
@@ -64,7 +64,7 @@ namespace Wangkanai.Detection.Services
         {
             var os       = OperatingSystem.Mac;
             var resolver = MockService.CreatePlatformService(agent);
-            Assert.Equal(os, resolver.OperatingSystem);
+            Assert.Equal(os, resolver.Name);
             Assert.Equal(processor, resolver.Processor);
         }
 
@@ -76,7 +76,7 @@ namespace Wangkanai.Detection.Services
         {
             var os       = OperatingSystem.Linux;
             var resolver = MockService.CreatePlatformService(agent);
-            Assert.Equal(os, resolver.OperatingSystem);
+            Assert.Equal(os, resolver.Name);
             Assert.Equal(processor, resolver.Processor);
         }
 
@@ -87,7 +87,7 @@ namespace Wangkanai.Detection.Services
         {
             var os       = OperatingSystem.Others;
             var resolver = MockService.CreatePlatformService(agent);
-            Assert.Equal(os, resolver.OperatingSystem);
+            Assert.Equal(os, resolver.Name);
             Assert.Equal(processor, resolver.Processor);
         }
     }


### PR DESCRIPTION
I believe that using the property as `Type` may cause miss understanding that this is `System.Type`. When its suppose to mean the name of the technology that the client request is using.
```html
<ul>
    <li>@Detection.Device?.Type</li>
    <li>@Detection.Browser?.Name</li>
    <li>@Detection.Platform?.Name</li>
    <li>@Detection.Engine?.Name</li>
</ul>
```