### PR TITLE
Change OperatingSystem to Platform

### DIFF
--- a/src/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/DependencyInjection/BuilderExtensions/Core.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2014-2020 Sarin Na Wangkanai, All Rights Reserved.
 // The Apache v2. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Wangkanai.Detection.DependencyInjection.Options;

--- a/src/Extensions/EnumExtensions.cs
+++ b/src/Extensions/EnumExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 
 namespace Wangkanai.Detection.Extensions

--- a/src/Extensions/UserAgentExtensions.cs
+++ b/src/Extensions/UserAgentExtensions.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.AspNetCore.Http;
 using Wangkanai.Detection.Models;
 
 namespace Wangkanai.Detection.Extensions

--- a/src/Models/Platform.cs
+++ b/src/Models/Platform.cs
@@ -6,7 +6,7 @@ using System;
 namespace Wangkanai.Detection.Models
 {
     [Flags]
-    public enum OperatingSystem
+    public enum Platform
     {
         Unknown = 0,
         Windows = 1 << 0, // Microsoft Windows

--- a/src/Services/BrowserService.cs
+++ b/src/Services/BrowserService.cs
@@ -4,7 +4,6 @@
 using System;
 using Wangkanai.Detection.Extensions;
 using Wangkanai.Detection.Models;
-using OperatingSystem = Wangkanai.Detection.Models.OperatingSystem;
 
 namespace Wangkanai.Detection.Services
 {
@@ -22,7 +21,7 @@ namespace Wangkanai.Detection.Services
             Version = GetVersion(agent.ToLower(), Name.ToString());
         }
 
-        private static Browser GetBrowser(UserAgent agent, OperatingSystem os, Engine engine)
+        private static Browser GetBrowser(UserAgent agent, Platform os, Engine engine)
         {
             // fail and return fast
             if (agent.IsNullOrEmpty())
@@ -80,7 +79,7 @@ namespace Wangkanai.Detection.Services
             => agent.Contains(Browser.Edge) 
                || (agent.Contains("Win64") && agent.Contains("Edg"));
 
-        private static bool IsInternetExplorer(UserAgent agent, OperatingSystem os, Engine engine)
+        private static bool IsInternetExplorer(UserAgent agent, Platform os, Engine engine)
             => engine == Engine.Trident 
                || agent.Contains("MSIE") 
                && !agent.Contains(Browser.Opera);

--- a/src/Services/EngineService.cs
+++ b/src/Services/EngineService.cs
@@ -18,7 +18,7 @@ namespace Wangkanai.Detection.Services
             Name = ParseEngine(agent, os, cpu);
         }
 
-        private static Engine ParseEngine(UserAgent agent, OperatingSystem os, Processor cpu)
+        private static Engine ParseEngine(UserAgent agent, Platform os, Processor cpu)
         {
             // Null check
             if (agent.IsNullOrEmpty())
@@ -50,9 +50,9 @@ namespace Wangkanai.Detection.Services
             => agent.Contains(Browser.Chrome)
                && agent.Contains(Engine.WebKit);
 
-        private static bool IsEdge(UserAgent agent, OperatingSystem os)
+        private static bool IsEdge(UserAgent agent, Platform os)
             => agent.Contains(Engine.EdgeHTML)
                || agent.Contains("Edg")
-               && (OperatingSystem.Windows | OperatingSystem.Android).HasFlag(os);
+               && (Platform.Windows | Platform.Android).HasFlag(os);
     }
 }

--- a/src/Services/Interfaces/IPlatformService.cs
+++ b/src/Services/Interfaces/IPlatformService.cs
@@ -16,8 +16,8 @@ namespace Wangkanai.Detection.Services
         public Processor Processor { get; }
         
         /// <summary>
-        /// Gets the <see cref="OperatingSystem"/> of the request client.
+        /// Gets the <see cref="Platform"/> of the request client.
         /// </summary>
-        public OperatingSystem Name { get; }
+        public Platform Name { get; }
     }
 }

--- a/src/Services/PlatformService.cs
+++ b/src/Services/PlatformService.cs
@@ -8,14 +8,14 @@ namespace Wangkanai.Detection.Services
 {
     public class PlatformService : IPlatformService
     {
-        public Processor       Processor       { get; }
-        public Platform Name { get; }
+        public Processor Processor { get; }
+        public Platform  Name      { get; }
 
         public PlatformService(IUserAgentService userAgentService)
         {
             var userAgent = userAgentService.UserAgent;
-            Name = ParseOperatingSystem(userAgent);
-            Processor       = ParseProcessor(userAgent, Name);
+            Name      = ParseOperatingSystem(userAgent);
+            Processor = ParseProcessor(userAgent, Name);
         }
 
         private static Platform ParseOperatingSystem(UserAgent agent)

--- a/src/Services/PlatformService.cs
+++ b/src/Services/PlatformService.cs
@@ -9,7 +9,7 @@ namespace Wangkanai.Detection.Services
     public class PlatformService : IPlatformService
     {
         public Processor       Processor       { get; }
-        public OperatingSystem Name { get; }
+        public Platform Name { get; }
 
         public PlatformService(IUserAgentService userAgentService)
         {
@@ -18,32 +18,32 @@ namespace Wangkanai.Detection.Services
             Processor       = ParseProcessor(userAgent, Name);
         }
 
-        private static OperatingSystem ParseOperatingSystem(UserAgent agent)
+        private static Platform ParseOperatingSystem(UserAgent agent)
         {
             // Unknown
             if (agent.IsNullOrEmpty())
-                return OperatingSystem.Unknown;
+                return Platform.Unknown;
 
             // Google Android
-            if (agent.Contains(OperatingSystem.Android))
-                return OperatingSystem.Android;
+            if (agent.Contains(Platform.Android))
+                return Platform.Android;
             // Microsoft Windows
-            if (agent.Contains(OperatingSystem.Windows))
-                return OperatingSystem.Windows;
+            if (agent.Contains(Platform.Windows))
+                return Platform.Windows;
             // Apple iOS
             if (IsiOS(agent))
-                return OperatingSystem.iOS;
+                return Platform.iOS;
             // Apple Mac
-            if (agent.Contains(OperatingSystem.Mac))
-                return OperatingSystem.Mac;
+            if (agent.Contains(Platform.Mac))
+                return Platform.Mac;
             // Linux Distribution
-            if (agent.Contains(OperatingSystem.Linux))
-                return OperatingSystem.Linux;
+            if (agent.Contains(Platform.Linux))
+                return Platform.Linux;
 
-            return OperatingSystem.Others;
+            return Platform.Others;
         }
 
-        private static Processor ParseProcessor(UserAgent agent, OperatingSystem os)
+        private static Processor ParseProcessor(UserAgent agent, Platform os)
         {
             if (IsArm(agent, os))
                 return Processor.ARM;
@@ -57,13 +57,13 @@ namespace Wangkanai.Detection.Services
             return Processor.Others;
         }
 
-        private static bool IsArm(UserAgent agent, OperatingSystem os)
+        private static bool IsArm(UserAgent agent, Platform os)
             => agent.Contains(Processor.ARM)
-               || agent.Contains(OperatingSystem.Android)
-               || os == OperatingSystem.iOS;
+               || agent.Contains(Platform.Android)
+               || os == Platform.iOS;
 
-        private static bool IsPowerPC(UserAgent agent, OperatingSystem os)
-            => os == OperatingSystem.Mac
+        private static bool IsPowerPC(UserAgent agent, Platform os)
+            => os == Platform.Mac
                && !agent.Contains("PPC");
 
         private static bool IsX86(UserAgent agent)
@@ -76,7 +76,7 @@ namespace Wangkanai.Detection.Services
                || agent.Contains("wow64");
 
         private static bool IsiOS(UserAgent agent)
-            => agent.Contains(OperatingSystem.iOS)
+            => agent.Contains(Platform.iOS)
                || agent.Contains(new[] {"iPad", "iPhone", "iPod"});
     }
 }

--- a/src/TagHelpers/DeviceTagHelper.cs
+++ b/src/TagHelpers/DeviceTagHelper.cs
@@ -14,10 +14,9 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
     [HtmlTargetElement(ElementName, Attributes = ExcludeAttributeName)]
     public class DeviceTagHelper : TagHelper
     {
-        protected     IHtmlGenerator Generator { get; }
-        private const string         ElementName          = "device";
-        private const string         IncludeAttributeName = "include";
-        private const string         ExcludeAttributeName = "exclude";
+        private const string ElementName          = "device";
+        private const string IncludeAttributeName = "include";
+        private const string ExcludeAttributeName = "exclude";
 
         private static readonly char[] NameSeparator = {','};
 
@@ -29,9 +28,8 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
         private readonly IDeviceService _resolver;
 
-        public DeviceTagHelper(IHtmlGenerator generator, IDeviceService resolver)
+        public DeviceTagHelper(IDeviceService resolver)
         {
-            Generator = generator ?? throw new ArgumentNullException(nameof(generator));
             _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
         }
 

--- a/test/DependencyInjection/ApplicationBuilderExtensionsTest.cs
+++ b/test/DependencyInjection/ApplicationBuilderExtensionsTest.cs
@@ -2,14 +2,11 @@
 // The Apache v2. See License.txt in the project root for license information.
 
 using System;
-
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-
 using Moq;
-
 using Xunit;
 
 namespace Wangkanai.Detection.DependencyInjection

--- a/test/DependencyInjection/BuilderExtensions/Responsive.csTest.cs
+++ b/test/DependencyInjection/BuilderExtensions/Responsive.csTest.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
-using Wangkanai.Detection.DependencyInjection.Options;
 using Wangkanai.Detection.Mocks;
 using Wangkanai.Detection.Models;
 using Xunit;

--- a/test/Hosting/PreferenceSessionTests.cs
+++ b/test/Hosting/PreferenceSessionTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Wangkanai.Detection.Mocks;
 using Xunit;
 
 namespace Wangkanai.Detection.Hosting
@@ -16,22 +17,15 @@ namespace Wangkanai.Detection.Hosting
         [Fact]
         public async Task ReadingEmptySessionDoesNotCreateCookie()
         {
-            var builder = new WebHostBuilder()
-                          .ConfigureServices(services => { services.AddDetection(); })
-                          .Configure(app =>
-                          {
-                              app.UseDetection();
-                              app.Run(context =>
-                              {
-                                  context.Session.SetString("Key", "Value");
-                                  return Task.FromResult(0);
-                              });
-                          });
+            var builder = MockServer.WebHostBuilder(context =>
+            {
+                context.Session.SetString("Key", "Value");
+                return Task.FromResult(0);
+            });
 
-            using var server = new TestServer(builder);
-
-            var client   = server.CreateClient();
-            var response = await client.GetAsync("/");
+            using var server   = MockServer.Server(builder);
+            var       client   = server.CreateClient();
+            var       response = await client.GetAsync("/");
             response.EnsureSuccessStatusCode();
             Assert.True(response.Headers.TryGetValues("Set-Cookie", out var values));
             Assert.Single(values);

--- a/test/Mocks/MockServer.cs
+++ b/test/Mocks/MockServer.cs
@@ -26,17 +26,23 @@ namespace Wangkanai.Detection.Mocks
         public static IWebHostBuilder WebHostBuilder()
             => WebHostBuilder(options => { });
 
+        public static IWebHostBuilder WebHostBuilder(RequestDelegate contextHandler)
+            => WebHostBuilder(contextHandler, options => { });
+        
         public static IWebHostBuilder WebHostBuilder(Action<DetectionOptions> options)
+            => WebHostBuilder(ContextHandler, options);
+
+        public static IWebHostBuilder WebHostBuilder(RequestDelegate contextHandler, Action<DetectionOptions> options)
             => new WebHostBuilder()
                .ConfigureServices(services =>
                    services.AddDetection(options))
                .Configure(app =>
                {
                    app.UseDetection();
-                   app.Run(ContextHandler());
+                   app.Run(contextHandler);
                });
 
-        private static RequestDelegate ContextHandler()
+        private static RequestDelegate ContextHandler
             => context => context.GetDevice() switch
             {
                 Device.Desktop => context.Response.WriteAsync("Response: Desktop"),

--- a/test/Services/PlatformServiceTest.cs
+++ b/test/Services/PlatformServiceTest.cs
@@ -14,7 +14,7 @@ namespace Wangkanai.Detection.Services
         {
             var resolver = MockService.Platform(null);
             Assert.NotNull(resolver);
-            Assert.Equal(OperatingSystem.Unknown, resolver.Name);
+            Assert.Equal(Platform.Unknown, resolver.Name);
             Assert.Equal(Processor.Others, resolver.Processor);
         }
 
@@ -25,7 +25,7 @@ namespace Wangkanai.Detection.Services
         [InlineData(Processor.ARM, "Mozilla/5.0 (Windows NT 10.0; ARM; RM-1096) AppleWebKit/537.36 (KHTML like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393")]
         public void Windows(Processor processor, string agent)
         {
-            var os       = OperatingSystem.Windows;
+            var os       = Platform.Windows;
             var resolver = MockService.Platform(agent);
             Assert.Equal(os, resolver.Name);
             Assert.Equal(processor, resolver.Processor);
@@ -37,7 +37,7 @@ namespace Wangkanai.Detection.Services
         [InlineData("Mozilla/5.0 (Linux; Android 4.4.2); Nexus 5 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.117 Mobile Safari/537.36 OPR/20.0.1396.72047")]
         public void Android(string agent)
         {
-            var os        = OperatingSystem.Android;
+            var os        = Platform.Android;
             var processor = Processor.ARM;
             var resolver  = MockService.Platform(agent);
             Assert.Equal(os, resolver.Name);
@@ -50,7 +50,7 @@ namespace Wangkanai.Detection.Services
         [InlineData("Mozilla/5.0 (iPod touch; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4")]
         public void iOS(string agent)
         {
-            var os        = OperatingSystem.iOS;
+            var os        = Platform.iOS;
             var processor = Processor.ARM;
             var resolver  = MockService.Platform(agent);
             Assert.Equal(os, resolver.Name);
@@ -63,7 +63,7 @@ namespace Wangkanai.Detection.Services
         [InlineData(Processor.Others, "Mozilla/5.0 (Macintosh; PPC Mac OS X x.y; rv:10.0) Gecko/20100101 Firefox/10.0")]
         public void Mac(Processor processor, string agent)
         {
-            var os       = OperatingSystem.Mac;
+            var os       = Platform.Mac;
             var resolver = MockService.Platform(agent);
             Assert.Equal(os, resolver.Name);
             Assert.Equal(processor, resolver.Processor);
@@ -75,7 +75,7 @@ namespace Wangkanai.Detection.Services
         [InlineData(Processor.ARM, "Mozilla/5.0 (Linux arm) Gecko/20110318 Firefox/4.0b13pre Fennec/4.0")]
         public void Linux(Processor processor, string agent)
         {
-            var os       = OperatingSystem.Linux;
+            var os       = Platform.Linux;
             var resolver = MockService.Platform(agent);
             Assert.Equal(os, resolver.Name);
             Assert.Equal(processor, resolver.Processor);
@@ -86,7 +86,7 @@ namespace Wangkanai.Detection.Services
         [InlineData(Processor.Others, "Mozilla/5.0 (X11; U; SunOS sun4u; en-US; rv:1.8.1.11) Gecko/20080118 Firefox/2.0.0.11")]
         public void Others(Processor processor, string agent)
         {
-            var os       = OperatingSystem.Others;
+            var os       = Platform.Others;
             var resolver = MockService.Platform(agent);
             Assert.Equal(os, resolver.Name);
             Assert.Equal(processor, resolver.Processor);


### PR DESCRIPTION
Their is a conflict with `System.OperatingSystem` and our `Wangkanai.Detection.Models.OperatingSystem`. Therefore, its better to change it to Platform that reflect more to our domain.

![image](https://user-images.githubusercontent.com/10666633/74164769-cb4de680-4c56-11ea-9538-46a84f592563.png)
