### PR TITLE
Benchmarks and performance improvements

### DIFF
--- a/Detection.sln
+++ b/Detection.sln
@@ -30,6 +30,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ResponsiveView", "sample\Re
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ResponsivePage", "sample\ResponsivePage\ResponsivePage.csproj", "{75375405-FA1D-4180-A128-DED0809AE891}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wangkanai.Benchmarks", "Wangkanai.Benchmarks\Wangkanai.Benchmarks.csproj", "{4EF175C1-1F7A-4AE9-BB83-FAC1118DE917}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -56,6 +58,10 @@ Global
 		{75375405-FA1D-4180-A128-DED0809AE891}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{75375405-FA1D-4180-A128-DED0809AE891}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{75375405-FA1D-4180-A128-DED0809AE891}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4EF175C1-1F7A-4AE9-BB83-FAC1118DE917}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4EF175C1-1F7A-4AE9-BB83-FAC1118DE917}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4EF175C1-1F7A-4AE9-BB83-FAC1118DE917}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4EF175C1-1F7A-4AE9-BB83-FAC1118DE917}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Wangkanai.Benchmarks/Program.cs
+++ b/Wangkanai.Benchmarks/Program.cs
@@ -1,0 +1,65 @@
+﻿using System.Linq;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using Microsoft.AspNetCore.Http;
+using Wangkanai.Detection.Services;
+
+namespace Wangkanai.Benchmarks
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            BenchmarkRunner.Run<DeviceBench>();
+        }
+    }
+    
+    
+    [MemoryDiagnoser]
+    public class DeviceBench
+    {
+        private static readonly string[] RawUserAgents = {
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.122 Safari/537.36",
+            "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.122 Safari/537.36",
+            "Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.122 Safari/537.36",
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.122 Safari/537.36",
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.122 Safari/537.36",
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 13_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/81.0.4044.124 Mobile/15E148 Safari/604.1",
+            "Mozilla/5.0 (iPad; CPU OS 13_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/81.0.4044.124 Mobile/15E148 Safari/604.1",
+            "Mozilla/5.0 (iPod; CPU iPhone OS 13_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/81.0.4044.124 Mobile/15E148 Safari/604.1",
+            "Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.117 Mobile Safari/537.36",
+            "Mozilla/5.0 (Linux; Android 10; SM-A205U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.117 Mobile Safari/537.36",
+            "Mozilla/5.0 (Linux; Android 10; SM-A102U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.117 Mobile Safari/537.36",
+            "Mozilla/5.0 (Linux; Android 10; SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.117 Mobile Safari/537.36",
+            "Mozilla/5.0 (Linux; Android 10; SM-N960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.117 Mobile Safari/537.36",
+            "Mozilla/5.0 (Linux; Android 10; LM-Q720) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.117 Mobile Safari/537.36",
+            "Mozilla/5.0 (Linux; Android 10; LM-X420) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.117 Mobile Safari/537.36",
+            "Mozilla/5.0 (Linux; Android 10; LM-Q710(FGN)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.117 Mobile Safari/537.36",
+        };
+
+        private static readonly HttpContextAccessor[] Accessors = 
+            RawUserAgents.Select(x => new HttpContextAccessor
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    Request =
+                    {
+                        Headers =
+                        {
+                            ["User-Agent"] = x
+                        }
+                    }
+                }
+            }).ToArray();
+
+        [Benchmark]
+        public void Detect()
+        {
+            foreach (var accessor in Accessors)
+            {
+                var deviceService = new DeviceService(new UserAgentService(accessor));
+                _ = deviceService.Type;
+            }
+        }
+    }
+}

--- a/Wangkanai.Benchmarks/Wangkanai.Benchmarks.csproj
+++ b/Wangkanai.Benchmarks/Wangkanai.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>netcoreapp3.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Wangkanai.Benchmarks/Wangkanai.Benchmarks.csproj
+++ b/Wangkanai.Benchmarks/Wangkanai.Benchmarks.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\src\Wangkanai.Detection.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Collections/MobileCollection.cs
+++ b/src/Collections/MobileCollection.cs
@@ -6,7 +6,7 @@ namespace Wangkanai.Detection.Collections
     internal static class MobileCollection
     {
         // mobile device keywords
-        public static string[] Keywords => new[]
+        public static readonly string[] Keywords = 
         {
             "iphone",
             "mobile",
@@ -38,7 +38,7 @@ namespace Wangkanai.Detection.Collections
         };
 
         // reference 4 character from http://www.webcab.de/wapua.htm
-        public static string[] Prefixes => new[]
+        public static readonly string[] Prefixes =
         {
             "w3c ",
             "w3c-",

--- a/src/Collections/TabletCollection.cs
+++ b/src/Collections/TabletCollection.cs
@@ -5,7 +5,7 @@ namespace Wangkanai.Detection.Collections
 {
     internal static class TabletCollection
     {
-        public static string[] Keywords => new[]
+        public static readonly string[] Keywords = 
         {
             "tablet",
             "ipad",
@@ -16,7 +16,7 @@ namespace Wangkanai.Detection.Collections
             "kfauwi"
         };
 
-        public static string[] Prefixes => new[]
+        public static readonly string[] Prefixes = 
         {
             "tablet"
         };

--- a/src/Extensions/UserAgentExtensions.cs
+++ b/src/Extensions/UserAgentExtensions.cs
@@ -13,10 +13,7 @@ namespace Wangkanai.Detection.Extensions
         public static bool IsNullOrEmpty(this UserAgent agent)
             => agent is null
                || string.IsNullOrEmpty(agent.ToLower());
-
-        public static string ToLower(this UserAgent agent)
-            => agent.ToString().ToLower();
-
+        
         public static int Length(this UserAgent agent)
             => agent.ToString().Length;
 
@@ -28,12 +25,15 @@ namespace Wangkanai.Detection.Extensions
         public static bool Contains(this UserAgent agent, string[] array)
             => !agent.IsNullOrEmpty()
                && array.Length > 0
-               && array.Any(agent.Contains);
+               && array.AnyContains(agent);
 
         public static bool Contains<T>(this UserAgent agent, T flags) where T : Enum
-            => flags.ToString().Contains(',')
-                ? flags.GetFlags().Any(agent.Contains)
-                : agent.Contains(flags.ToString());
+        {
+            var strFlags = flags.ToString();
+            return strFlags.Contains(',')
+                       ? flags.GetFlags().Any(agent.Contains)
+                       : agent.Contains(strFlags);
+        }
 
         public static bool Contains(this UserAgent agent, IEnumerable<string> list)
             => !agent.IsNullOrEmpty()
@@ -46,10 +46,30 @@ namespace Wangkanai.Detection.Extensions
                && agent.ToLower().StartsWith(word.ToLower());
 
         public static bool StartsWith(this UserAgent agent, string[] array)
-            => array.Any(agent.StartsWith);
+            => array.AnyStartsWith(agent);
 
         public static bool StartsWith(this UserAgent agent, string[] array, int minimum)
             => agent.Length() >= minimum
                && agent.StartsWith(array);
+
+        private static bool AnyStartsWith(this string[] array, UserAgent agent)
+        {
+            foreach (var str in array)
+            {
+                if (agent.StartsWith(str)) return true;
+            }
+
+            return false;
+        }
+        
+        private static bool AnyContains(this string[] array, UserAgent agent)
+        {
+            foreach (var str in array)
+            {
+                if (agent.Contains(str)) return true;
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Models/UserAgent.cs
+++ b/src/Models/UserAgent.cs
@@ -8,15 +8,25 @@ namespace Wangkanai.Detection.Models
     public class UserAgent
     {
         private readonly string _useragent;
+        private readonly string _useragentLower;
 
         public UserAgent()
-            => _useragent = string.Empty;
+        {
+            _useragent      = string.Empty;
+            _useragentLower = string.Empty;
+        }
 
         public UserAgent(string useragent) : this()
-            => _useragent = useragent ?? string.Empty;
+        {
+            _useragent      = useragent ?? string.Empty;
+            _useragentLower = _useragent.ToLower();
+        }
 
         [DebuggerStepThrough]
         public override string ToString()
             => _useragent;
+
+        public string ToLower() 
+            => _useragentLower;
     }
 }


### PR DESCRIPTION
I've added benchmarks project and improved device detection hot path performance.

Core idea: 
- do not lowercase user agent string for every check (major perf boost)
- do not allocate delegates on array comparison (minor perf boost)

Hardware and Software

```
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.17763.1158 (1809/October2018Update/Redstone5)
Intel Core i5-3570K CPU 3.40GHz (Ivy Bridge), 1 CPU, 4 logical and 4 physical cores
.NET Core SDK=3.1.102
  [Host]  : .NET Core 3.1.2 (CoreCLR 4.700.20.6602, CoreFX 4.700.20.6702), X64 RyuJIT
  LongRun : .NET Core 3.1.2 (CoreCLR 4.700.20.6602, CoreFX 4.700.20.6702), X64 RyuJIT
```

Before:

| Method |     Mean |    Error |   StdDev |   Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |---------:|---------:|---------:|--------:|------:|------:|----------:|
| Detect | 92.13 us | 0.397 us | 2.053 us | 44.9219 |     - |     - | 137.66 KB |

After: only `ToLower()`

| Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |---------:|---------:|---------:|-------:|------:|------:|----------:|
| Detect | 30.94 us | 0.195 us | 0.173 us | 7.6294 |     - |     - |  23.51 KB |

After: do not allocate delegates +  `ToLower()`

| Method |     Mean |    Error |   StdDev |   Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |---------:|---------:|---------:|---------:|-------:|------:|------:|----------:|
| Detect | 29.03 us | 0.094 us | 0.486 us | 28.95 us | 6.2256 |     - |     - |  19.13 KB |