### PR TITLE
Transient to Scoped registration for core services

### DIFF
--- a/src/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/DependencyInjection/BuilderExtensions/Core.cs
@@ -29,13 +29,13 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IDetectionBuilder AddCoreServices(this IDetectionBuilder builder)
         {
             // Add Basic core to services
-            builder.Services.TryAddTransient<IUserAgentService, UserAgentService>();
-            builder.Services.TryAddTransient<IDeviceService, DeviceService>();
-            builder.Services.TryAddTransient<IEngineService, EngineService>();
-            builder.Services.TryAddTransient<IPlatformService, PlatformService>();
-            builder.Services.TryAddTransient<IBrowserService, BrowserService>();
-            builder.Services.TryAddTransient<ICrawlerService, CrawlerService>();
-            builder.Services.TryAddTransient<IDetectionService, DetectionService>();
+            builder.Services.TryAddScoped<IUserAgentService, UserAgentService>();
+            builder.Services.TryAddScoped<IDeviceService, DeviceService>();
+            builder.Services.TryAddScoped<IEngineService, EngineService>();
+            builder.Services.TryAddScoped<IPlatformService, PlatformService>();
+            builder.Services.TryAddScoped<IBrowserService, BrowserService>();
+            builder.Services.TryAddScoped<ICrawlerService, CrawlerService>();
+            builder.Services.TryAddScoped<IDetectionService, DetectionService>();
 
             return builder;
         }

--- a/src/Services/ResponsiveService.cs
+++ b/src/Services/ResponsiveService.cs
@@ -12,24 +12,24 @@ namespace Wangkanai.Detection.Services
 {
     public class ResponsiveService : IResponsiveService
     {
-        public Device View { get; }
+        public Device View => PreferView(_context, _defaultView);
 
         private readonly HttpContext _context;
+        private readonly Device      _defaultView;
         private const    string      ResponsiveContextKey = "Responsive";
 
         public ResponsiveService(IHttpContextAccessor accessor, IDeviceService deviceService, DetectionOptions options)
         {
             if (accessor is null)
                 throw new ArgumentNullException(nameof(accessor));
+
             if (deviceService is null)
                 throw new ArgumentNullException(nameof(deviceService));
-            if (options is null)
-                options = new DetectionOptions();
 
-            _context = accessor.HttpContext;
+            options = options ?? new DetectionOptions();
 
-            View = DefaultView(deviceService.Type, options.Responsive);
-            View = PreferView(_context, View);
+            _context     = accessor.HttpContext;
+            _defaultView = DefaultView(deviceService.Type, options.Responsive);
         }
 
         public void PreferSet(Device desktop)


### PR DESCRIPTION
I am not sure about this one, seems like nothing prevents scoped registration unless I've missed something.

This should help reduce allocations in the scenario when detection services are injected by user code in several places during request lifetime