### PR TITLE
Added fix for detecting Edge version

### DIFF
--- a/src/Services/BrowserService.cs
+++ b/src/Services/BrowserService.cs
@@ -2,6 +2,7 @@
 // The Apache v2. See License.txt in the project root for license information.
 
 using System;
+
 using Wangkanai.Detection.Extensions;
 using Wangkanai.Detection.Models;
 
@@ -9,15 +10,15 @@ namespace Wangkanai.Detection.Services
 {
     public class BrowserService : IBrowserService
     {
-        public Browser Name    { get; }
+        public Browser Name { get; }
         public Version Version { get; }
 
         public BrowserService(IUserAgentService userAgentService, IPlatformService platformService, IEngineService engineService)
         {
-            var agent  = userAgentService.UserAgent;
-            var os     = platformService.Name;
+            var agent = userAgentService.UserAgent;
+            var os = platformService.Name;
             var engine = engineService.Name;
-            Name    = GetBrowser(agent, os, engine);
+            Name = GetBrowser(agent, os, engine);
             Version = GetVersion(agent.ToLower(), Name.ToString());
         }
 
@@ -60,7 +61,10 @@ namespace Wangkanai.Detection.Services
             if (agent.Contains("msie 9"))
                 return new Version(9, 0);
 
-            var    first = agent.IndexOf(browser.ToLower(), StringComparison.Ordinal);
+            if (IsEdge(new UserAgent(agent)) && agent.Contains("Edg/", StringComparison.InvariantCultureIgnoreCase))
+                agent = agent.Replace("edg", "edge", StringComparison.InvariantCultureIgnoreCase);
+
+            var first = agent.IndexOf(browser.ToLower(), StringComparison.Ordinal);
             string cut;
             try
             {
@@ -76,12 +80,12 @@ namespace Wangkanai.Detection.Services
         }
 
         private static bool IsEdge(UserAgent agent)
-            => agent.Contains(Browser.Edge) 
+            => agent.Contains(Browser.Edge)
                || (agent.Contains("Win64") && agent.Contains("Edg"));
 
         private static bool IsInternetExplorer(UserAgent agent, Platform os, Engine engine)
-            => engine == Engine.Trident 
-               || agent.Contains("MSIE") 
+            => engine == Engine.Trident
+               || agent.Contains("MSIE")
                && !agent.Contains(Browser.Opera);
     }
 }

--- a/test/Services/BrowserServiceTest.cs
+++ b/test/Services/BrowserServiceTest.cs
@@ -2,8 +2,10 @@
 // The Apache v2. See License.txt in the project root for license information.
 
 using System;
+
 using Wangkanai.Detection.Mocks;
 using Wangkanai.Detection.Models;
+
 using Xunit;
 
 namespace Wangkanai.Detection.Services
@@ -72,14 +74,17 @@ namespace Wangkanai.Detection.Services
         }
 
         [Theory]
-        [InlineData("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.74 Safari/537.36 Edg/79.0.309.43")]
-        [InlineData("Mozilla/5.0 (Windows Mobile 10; Android 8.0.0; Microsoft; Lumia 950XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36 Edge/40.15254.369")]
-        [InlineData("Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox One) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36 Edge/40.15063.0")]
-        [InlineData("Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.9200")]
-        public void Edge(string agent)
+        [InlineData("79.0.309.43", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.74 Safari/537.36 Edg/79.0.309.43")]
+        [InlineData("40.15254.369", "Mozilla/5.0 (Windows Mobile 10; Android 8.0.0; Microsoft; Lumia 950XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36 Edge/40.15254.369")]
+        [InlineData("40.15063.0", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox One) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36 Edge/40.15063.0")]
+        [InlineData("13.9200", "Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.9200")]
+        [InlineData("18.19041", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.19041")]
+        [InlineData("85.0.564.51", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.102 Safari/537.36 Edg/85.0.564.51")]
+        public void Edge(string version, string agent)
         {
             var resolver = MockService.Browser(agent);
             Assert.Equal(Browser.Edge, resolver.Name);
+            Assert.Equal(new Version(version), resolver.Version);
         }
 
         [Theory]


### PR DESCRIPTION
Fixes #422 

Replaces "edg" with "edge" on version detection if browser is edge.

Extended unit tests to encompass versions for Edge, including Chromium based versions

Related #360 