### PR TITLE
Added support to use the detection service outside of a httprequest

### DIFF
--- a/src/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/DependencyInjection/BuilderExtensions/Core.cs
@@ -1,8 +1,9 @@
-// Copyright (c) 2014-2020 Sarin Na Wangkanai, All Rights Reserved.
+﻿// Copyright (c) 2014-2020 Sarin Na Wangkanai, All Rights Reserved.
 // The Apache v2. See License.txt in the project root for license information.
 
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
+
 using Wangkanai.Detection.DependencyInjection.Options;
 using Wangkanai.Detection.Services;
 
@@ -36,6 +37,7 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.TryAddScoped<IBrowserService, BrowserService>();
             builder.Services.TryAddScoped<ICrawlerService, CrawlerService>();
             builder.Services.TryAddScoped<IDetectionService, DetectionService>();
+            builder.Services.TryAddScoped<IDetectionService, ManualDetectionService>();
 
             return builder;
         }

--- a/src/Services/ManualDetectionService.cs
+++ b/src/Services/ManualDetectionService.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Http;
+
+using Wangkanai.Detection.DependencyInjection.Options;
+using Wangkanai.Detection.Models;
+
+namespace Wangkanai.Detection.Services
+{
+    public class ManualDetectionService : IDetectionService
+    {
+        public UserAgent UserAgent { get; }
+        public IDeviceService Device { get; }
+        public ICrawlerService Crawler { get; }
+        public IBrowserService Browser { get; }
+        public IEngineService Engine { get; }
+        public IPlatformService Platform { get; }
+
+        public ManualDetectionService(string userAgent, DetectionOptions options = null!)
+        {
+            var contextAccessor = new HttpContextAccessor()
+            {
+                HttpContext = new DefaultHttpContext()
+                {
+                    Request = { Headers = { { "User-Agent", new[] { userAgent } } } }
+                }
+            };
+            var userAgentService = new UserAgentService(contextAccessor);
+            UserAgent = userAgentService.UserAgent;
+            Device = new DeviceService(userAgentService);
+            Crawler = new CrawlerService(userAgentService, options);
+            Platform = new PlatformService(userAgentService);
+            Engine = new EngineService(userAgentService, Platform);
+            Browser = new BrowserService(userAgentService, Platform, Engine);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #386 

Added a "mirroring" service implementing, the same interface as the DetectionService, but it "mocks" a HttpContextAccessor, so it can be used just like any other DI service