### PR TITLE
Modified the modelling of the Edge browser with different engines

### DIFF
--- a/benchmark/Wangkanai.Detection.Benchmark.csproj
+++ b/benchmark/Wangkanai.Detection.Benchmark.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
     <Nullable>annotations</Nullable>

--- a/src/Extensions/HttpContextExtensions.cs
+++ b/src/Extensions/HttpContextExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Http
                 throw new ArgumentNullException(nameof(context.Items));
 
             return context.Items.TryGetValue(ResponsiveContextKey, out var responsive)
-                       ? (Device) responsive
+                       ? (Device) (responsive ?? Device.Unknown)
                        : Device.Desktop;
         }
     }

--- a/src/Services/EngineService.cs
+++ b/src/Services/EngineService.cs
@@ -59,8 +59,6 @@ namespace Wangkanai.Detection.Services
                && agent.Contains(Engine.WebKit);
 
         private static bool IsEdge(UserAgent agent, Platform os)
-            => agent.Contains(Engine.Edge)
-               || agent.Contains("Edg")
-               && (Platform.Windows | Platform.Android).HasFlag(os);
+            => agent.Contains(Engine.Edge);
     }
 }

--- a/src/Services/HttpContextService.cs
+++ b/src/Services/HttpContextService.cs
@@ -9,11 +9,21 @@ namespace Wangkanai.Detection.Services
         public HttpContext Context { get; }
         public HttpRequest Request => Context.Request;
 
-        public HttpContextService(IHttpContextAccessor accessor) 
-            => Context = accessor?.HttpContext 
-                         ?? new DefaultHttpContext();
+        public HttpContextService(IHttpContextAccessor accessor)
+        {
+            if (accessor == null) throw new ArgumentNullException(nameof(accessor));
+            if (accessor == null) throw new ArgumentNullException(nameof(accessor));
+            if (accessor == null) throw new ArgumentNullException(nameof(accessor));
+            if (accessor == null) throw new ArgumentNullException(nameof(accessor));
+            Context = accessor?.HttpContext ?? new DefaultHttpContext();
+        }
+        
+        private HttpContextService()
+        {
+            Context = new DefaultHttpContext();
+        }
 
         public static HttpContextService CreateService()
-            => new(null!);
+            => new HttpContextService();
     }
 }

--- a/src/Wangkanai.Detection.csproj
+++ b/src/Wangkanai.Detection.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>4.0.0</VersionPrefix>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/test/Services/EngineServiceTest.cs
+++ b/test/Services/EngineServiceTest.cs
@@ -43,6 +43,7 @@ namespace Wangkanai.Detection.Services
         [InlineData(Engine.Blink, "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.19 (KHTML, like Gecko) Chrome/1.0.154.53 Safari/525.19")]
         [InlineData(Engine.Blink, "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Atom/4.0.0.141 Safari/537.36")]
         [InlineData(Engine.Blink, "Mozilla/5.0 (X11; U; Linux x86_64; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Ubuntu/10.10 Chromium/8.0.552.237 Chrome/8.0.552.237 Safari/534.10")]
+        [InlineData(Engine.Blink, "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.74 Safari/537.36 Edg/79.0.309.43")]
         public void Blink(Engine engine, string agent)
         {
             var resolver = MockService.EngineService(agent);
@@ -60,7 +61,6 @@ namespace Wangkanai.Detection.Services
         }
 
         [Theory]
-        [InlineData(Engine.Edge, "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.74 Safari/537.36 Edg/79.0.309.43")]
         [InlineData(Engine.Edge, "Mozilla/5.0 (Windows Mobile 10; Android 8.0.0; Microsoft; Lumia 950XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36 Edge/40.15254.369")]
         [InlineData(Engine.Edge, "Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox One) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36 Edge/40.15063.0")]
         [InlineData(Engine.Edge, "Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.9200")]

--- a/test/Wangkanai.Detection.Test.csproj
+++ b/test/Wangkanai.Detection.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>default</LangVersion>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
I experienced an issue using the tag helpers to differentiation between Edge Legacy and Edge Chromium as they are very different browsers. The proposed approach is to retain the Browser detected as Edge for both cases but differentiate them based on the engine. This PR will result in Edge Legacy returning Edge as the engine and Edge Chromium returning Blink as the engine. I find this makes it easier to handle differentiation of that major Edge change Microsoft made recently.

This PR also adds netcoreapp3.1 as one of the target frameworks - just because the app I'm working hasn't yet moved to net5.0.