### PR TITLE
#488 iPadOS version parsing fixed

### DIFF
--- a/src/Extensions/HttpContextExtensions.cs
+++ b/src/Extensions/HttpContextExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 
 using Wangkanai.Detection.Models;
+using Wangkanai.Runtime;
 
 namespace Wangkanai.Detection.Extensions
 {
@@ -24,13 +25,11 @@ namespace Wangkanai.Detection.Extensions
 
         public static Device GetDevice(this HttpContext context)
         {
-            if (context is null)
-                throw new ArgumentNullException(nameof(context));
-            if (context.Items is null)
-                throw new ArgumentNullException(nameof(context.Items));
+            Check.NotNull(context, nameof(context));
+            Check.NotNull(context.Items, nameof(context.Items));
 
             return context.Items.TryGetValue(ResponsiveContextKey, out var responsive)
-                       ? ((responsive as Device?) ?? Device.Unknown)
+                       ? (responsive as Device?) ?? Device.Unknown
                        : Device.Desktop;
         }
     }

--- a/src/Extensions/UserAgentExtensions.cs
+++ b/src/Extensions/UserAgentExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Wangkanai.Detection.Models;
 
 namespace Wangkanai.Detection.Extensions
@@ -12,19 +13,16 @@ namespace Wangkanai.Detection.Extensions
     {
         public static bool IsNullOrEmpty(this UserAgent agent)
             => string.IsNullOrEmpty(agent.ToString());
-        
-        public static int Length(this UserAgent agent)
-            => agent.ToString().Length;
 
         public static bool Contains(this UserAgent agent, string word)
-            => (!agent.IsNullOrEmpty() && !word.IsNullOrEmpty())
+            => !agent.IsNullOrEmpty()
+               && !word.IsNullOrEmpty()
                && agent.ToLower().Contains(word.ToLower());
 
         public static bool Contains(this UserAgent agent, string[] array)
             => !agent.IsNullOrEmpty()
                && array.Length > 0
                && array.AnyContains(agent);
-        
 
         public static bool Contains<T>(this UserAgent agent, T flags) where T : Enum
         {
@@ -37,10 +35,10 @@ namespace Wangkanai.Detection.Extensions
         public static bool Contains(this UserAgent agent, IEnumerable<string> list)
             => !agent.IsNullOrEmpty()
                && list.Any(agent.Contains);
-        
-        public static UserAgent Replace(this UserAgent agent, string oldValue, string newValue) 
-            => agent.IsNullOrEmpty() && oldValue.IsNullOrEmpty() 
-                   ? agent 
+
+        public static UserAgent Replace(this UserAgent agent, string oldValue, string newValue)
+            => agent.IsNullOrEmpty() && oldValue.IsNullOrEmpty()
+                   ? agent
                    : new UserAgent(agent.ToLower().Replace(oldValue, newValue));
 
         public static int IndexOf(this UserAgent agent, string word)
@@ -49,10 +47,9 @@ namespace Wangkanai.Detection.Extensions
 
         public static int IndexOf(this UserAgent agent, Browser browser)
             => agent.IndexOf(browser.ToString());
-        
+
         public static string Substring(this UserAgent agent, int start)
-            => agent.ToLower()
-                    .Substring(start);
+            => agent.ToLower()[start..];
 
         public static string Substring(this UserAgent agent, int start, int length)
             => agent.ToLower()
@@ -61,7 +58,7 @@ namespace Wangkanai.Detection.Extensions
         public static string[] Split(this UserAgent agent, char separator)
             => agent.ToLower()
                     .Split(separator);
-        
+
         public static bool StartsWith(this UserAgent agent, string word)
             => !word.IsNullOrEmpty()
                && !agent.IsNullOrEmpty()
@@ -75,10 +72,10 @@ namespace Wangkanai.Detection.Extensions
             => agent.Length() >= minimum
                && agent.StartsWith(array);
 
-        private static bool AnyStartsWith(this string[] array, UserAgent agent) 
+        private static bool AnyStartsWith(this string[] array, UserAgent agent)
             => array.Any(agent.StartsWith);
 
-        private static bool AnyContains(this string[] array, UserAgent agent) 
+        private static bool AnyContains(this string[] array, UserAgent agent)
             => array.Any(agent.Contains);
     }
 }

--- a/src/Models/Platform.cs
+++ b/src/Models/Platform.cs
@@ -12,8 +12,9 @@ namespace Wangkanai.Detection.Models
         Windows = 1 << 0, // Microsoft Windows
         Mac     = 1 << 1, // Apple MacOS
         iOS     = 1 << 2, // Apple iOS
-        Linux   = 1 << 3, // Linux Distribution (Red Hat, Mint, Ubuntu)
-        Android = 1 << 4, // Google Android
-        Others  = 1 << 5  // Others
+        iPadOS  = 1 << 3, // Apple iPadOS
+        Linux   = 1 << 4, // Linux Distribution (Red Hat, Mint, Ubuntu)
+        Android = 1 << 5, // Google Android
+        Others  = 1 << 6  // Others
     }
 }

--- a/src/Models/UserAgent.cs
+++ b/src/Models/UserAgent.cs
@@ -7,26 +7,31 @@ namespace Wangkanai.Detection.Models
 {
     public class UserAgent
     {
-        private readonly string _useragent;
-        private readonly string _useragentLower;
+        private readonly string _original;
+        private readonly string _lower;
+        private readonly int    _length;
 
         public UserAgent()
         {
-            _useragent      = string.Empty;
-            _useragentLower = string.Empty;
+            _original = string.Empty;
+            _lower    = string.Empty;
+            _length   = 0;
         }
 
         public UserAgent(string useragent) : this()
         {
-            _useragent      = useragent ?? string.Empty;
-            _useragentLower = _useragent.ToLower();
+            _original = useragent ?? string.Empty;
+            _lower    = _original.ToLower();
+            _length   = _original.Length;
         }
 
         [DebuggerStepThrough]
-        public override string ToString()
-            => _useragent;
+        public override string ToString() => _original;
 
-        public string ToLower() 
-            => _useragentLower;
+        [DebuggerStepThrough]
+        public string ToLower() => _lower;
+
+        [DebuggerStepThrough]
+        public int Length() => _length;
     }
 }

--- a/src/Services/BrowserService.cs
+++ b/src/Services/BrowserService.cs
@@ -75,6 +75,9 @@ namespace Wangkanai.Detection.Services
             var name = browser.ToStringInvariant();
             var first = agent.IndexOf(name, StringComparison.Ordinal);
 
+            if (first < 0 || first + name.Length > agent.Length)
+                return new Version();
+            
             string cut;
             if (agent.Length > first + name.Length + 1)
             {

--- a/src/Services/PlatformService.cs
+++ b/src/Services/PlatformService.cs
@@ -34,6 +34,8 @@ namespace Wangkanai.Detection.Services
                 return Platform.Android;
             if (agent.Contains(Platform.Windows))
                 return Platform.Windows;
+            if (IsiPadOS(agent))
+                return Platform.iPadOS;
             if (IsiOS(agent))
                 return Platform.iOS;
             if (agent.Contains(Platform.Mac))
@@ -46,19 +48,20 @@ namespace Wangkanai.Detection.Services
 
         private Version GetVersion()
         {
-            var agent = _userAgentService.UserAgent.ToLower();
+            var agent    = _userAgentService.UserAgent.ToLower();
             var platform = Name;
             return platform switch
-            {
-                Platform.Unknown => new Version(),
-                Platform.Others => new Version(),
-                Platform.Windows => ParseOsVersion(agent, "windowsnt"),
-                Platform.Android => ParseOsVersion(agent, "android"),
-                Platform.Mac => ParseOsVersion(agent, "intelmacosx"),
-                Platform.iOS => ParseOsVersion(agent, "cpuiphoneos"),
-                Platform.Linux => ParseOsVersion(agent, "rv:"),
-                _ => new Version()
-            };
+                   {
+                       Platform.Unknown => new Version(),
+                       Platform.Others  => new Version(),
+                       Platform.Windows => ParseOsVersion(agent, "windowsnt"),
+                       Platform.Android => ParseOsVersion(agent, "android"),
+                       Platform.Mac     => ParseOsVersion(agent, "intelmacosx"),
+                       Platform.iOS     => ParseOsVersion(agent, "cpuiphoneos"),
+                       Platform.iPadOS  => ParseOsVersion(agent, "cpuos"),
+                       Platform.Linux   => ParseOsVersion(agent, "rv:"),
+                       _                => new Version()
+                   };
         }
 
         private static readonly Regex _osStartRegex = new Regex(@"\(([^\)]+)\)", RegexOptions.Compiled);
@@ -68,22 +71,22 @@ namespace Wangkanai.Detection.Services
 
         private static Version ParseOsVersion(string agent, string versionPrefix) =>
             _osParseRegex.RegexMatch(
-                    (_osStartRegex.RegexMatch(agent)
-                         .Captures[0]
+                             (_osStartRegex.RegexMatch(agent)
+                                           .Captures[0]
+                                           .Value
+                                           .RemoveAll(" ", "(", ")")
+                                           .Split(';')
+                                           .FirstOrDefault(x => x.StartsWith(versionPrefix, StringComparison.Ordinal)) ??
+                              string.Empty)
+                             .Replace("_", ".")
+                         )
                          .Value
-                         .RemoveAll(" ", "(", ")")
-                         .Split(';')
-                         .FirstOrDefault(x => x.StartsWith(versionPrefix, StringComparison.Ordinal)) ??
-                     string.Empty)
-                    .Replace("_", ".")
-                )
-                .Value
-                .ToVersion();
+                         .ToVersion();
 
         private Processor GetProcessor()
         {
             var agent = _userAgentService.UserAgent.ToLower();
-            var os = Name;
+            var os    = Name;
 
             if (IsArm(agent, os))
                 return Processor.ARM;
@@ -100,26 +103,31 @@ namespace Wangkanai.Detection.Services
         private static bool IsArm(string agent, Platform os)
             => agent.Contains(Processor.ARM)
                || agent.Contains(Platform.Android)
-               || os == Platform.iOS;
+               || os is Platform.iOS or Platform.iPadOS;
 
         private static bool IsPowerPC(string agent, Platform os)
             => os == Platform.Mac
                && !agent.Contains("ppc", StringComparison.Ordinal);
 
-        private static readonly string[] X86DeviceList = {"i86", "i686", Processor.x86.ToStringInvariant()};
+        private static readonly string[]  X86DeviceList     = {"i86", "i686", Processor.x86.ToStringInvariant()};
+        private static readonly IndexTree X86DeviceIndex    = X86DeviceList.BuildIndexTree();
+        private static readonly string[]  X64DeviceList     = {"x86_64", "wow64", Processor.x64.ToStringInvariant()};
+        private static readonly IndexTree X64DeviceIndex    = X64DeviceList.BuildIndexTree();
+        private static readonly string[]  IosDeviceList     = {"ipad", "iphone", "ipod", Platform.iOS.ToStringInvariant()};
+        private static readonly IndexTree IosDeviceIndex    = IosDeviceList.BuildIndexTree();
+        private static readonly string[]  IPadosDeviceList  = {"ipad", Platform.iPadOS.ToStringInvariant()};
+        private static readonly IndexTree IPadosDeviceIndex = IPadosDeviceList.BuildIndexTree();
 
-        private static readonly IndexTree _x86DeviceIndex = X86DeviceList.BuildIndexTree();
+        private static bool IsX86(string agent)
+            => agent.SearchContains(X86DeviceIndex);
 
-        private static bool IsX86(string agent) => agent.SearchContains(_x86DeviceIndex);
+        private static bool IsX64(string agent)
+            => agent.SearchContains(X64DeviceIndex);
 
-        private static readonly string[] X64DeviceList = {"x86_64", "wow64", Processor.x64.ToStringInvariant()};
+        private static bool IsiOS(string agent)
+            => agent.SearchContains(IosDeviceIndex);
 
-        private static readonly IndexTree _x64DeviceIndex = X64DeviceList.BuildIndexTree();
-        private static bool IsX64(string agent) => agent.SearchContains(_x64DeviceIndex);
-
-        private static readonly string[] IosDeviceList = {"ipad", "iphone", "ipod", Platform.iOS.ToStringInvariant()};
-
-        private static readonly IndexTree _iosDeviceIndex = IosDeviceList.BuildIndexTree();
-        private static bool IsiOS(string agent) => agent.SearchContains(_iosDeviceIndex);
+        private static bool IsiPadOS(string agent)
+            => agent.SearchContains(IPadosDeviceIndex);
     }
 }

--- a/src/Wangkanai.Detection.csproj
+++ b/src/Wangkanai.Detection.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/test/Services/PlatformServiceTest.cs
+++ b/test/Services/PlatformServiceTest.cs
@@ -56,17 +56,32 @@ namespace Wangkanai.Detection.Services
         }
 
         [Theory]
-        [InlineData("Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4")]
-        [InlineData("Mozilla/5.0 (iPod touch; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4")]
-        [InlineData("Mozilla/5.0 (iPad; U; CPU OS 4_3_5 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8L1 Safari/6533.18.5")]
-        [InlineData("Mozilla/5.0 (iPad; CPU OS 12_4_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Mobile/15E148 Safari/604.1")]
-        public void iOS(string agent)
+        [InlineData("8.3", "Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4")]
+        [InlineData("8.3", "Mozilla/5.0 (iPod touch; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4")]
+        public void iOS(string target, string agent)
         {
-            var os = Platform.iOS;
+            var os        = Platform.iOS;
             var processor = Processor.ARM;
-            var resolver = MockService.PlatformService(agent);
+            var version   = new Version(target);
+            var resolver  = MockService.PlatformService(agent);
             Assert.Equal(os, resolver.Name);
             Assert.Equal(processor, resolver.Processor);
+            Assert.Equal(version, resolver.Version);
+            _testOutputHelper.WriteLine(resolver.Version.ToString());
+        }
+        
+        [Theory]
+        [InlineData("4.3.5", "Mozilla/5.0 (iPad; U; CPU OS 4_3_5 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8L1 Safari/6533.18.5")]
+        [InlineData("12.4.2", "Mozilla/5.0 (iPad; CPU OS 12_4_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Mobile/15E148 Safari/604.1")]
+        public void iPadOS(string target, string agent)
+        {
+            var os        = Platform.iPadOS;
+            var processor = Processor.ARM;
+            var version   = new Version(target);
+            var resolver  = MockService.PlatformService(agent);
+            Assert.Equal(os, resolver.Name);
+            Assert.Equal(processor, resolver.Processor);
+            Assert.Equal(version, resolver.Version);
             _testOutputHelper.WriteLine(resolver.Version.ToString());
         }
 


### PR DESCRIPTION
I have split the iOS and iPadOS platform out from each other. While this a breaking changes in the platform enumeration index. But i think it a good upgrade.

![image](https://user-images.githubusercontent.com/10666633/117559067-5f9e3780-b0ac-11eb-8507-c87d236cb8f2.png)
