### PR TITLE
fix: out of range exception on platform version

### DIFF
--- a/src/Services/PlatformService.cs
+++ b/src/Services/PlatformService.cs
@@ -75,7 +75,8 @@ namespace Wangkanai.Detection.Services
         private static Version ParseOsVersion(string agent, string versionPrefix) =>
             _osParseRegex.RegexMatch(
                              (_osStartRegex.RegexMatch(agent)
-                                           .Captures[0]
+                                           .Captures
+                                           .FirstOrDefault()?
                                            .Value
                                            .RemoveAll(" ", "(", ")")
                                            .Split(';')

--- a/test/Services/PlatformServiceTest.cs
+++ b/test/Services/PlatformServiceTest.cs
@@ -148,6 +148,13 @@ namespace Wangkanai.Detection.Services
         [InlineData("10.0", "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; Touch; LCJB; rv:11.0) like Gecko")] // Win10
         [InlineData("10.9.3", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.75.14 (KHTML, like Gecko) Version/7.0.3 Safari/7046A194A")] // OSX
         [InlineData("0.0", "")] // Other
+        [InlineData("0.0", "iphone applewebkit")]
+        [InlineData("0.0", "ipad applewebkit")]
+        [InlineData("0.0", "android")]
+        [InlineData("0.0", "windows")]
+        [InlineData("0.0", "mac")]
+        [InlineData("0.0", "linux")]
+        [InlineData("0.0", "random")]
         public void GetVersion(string version, string agent)
         {
             var resolver = MockService.PlatformService(agent);


### PR DESCRIPTION
Solves https://github.com/wangkanai/Detection/issues/499 and https://github.com/wangkanai/Detection/issues/502

There is an issue that, in case there is a match on `PlatformServices.GetPlatform()` for platforms other than `Unknown` or `Other`, `PlatformServices.ParseOsVersion()` method might throw a `System.ArgumentOutOfRangeException` if there is no match for the `_osStartRegex` pattern - `@"\(([^\)]+)\)"`

By using `FirstOrDefault` instead of `[0]` we can avoid this.

Unit tests before the change
![image](https://user-images.githubusercontent.com/5676817/135537030-e75640a3-9260-4645-b2e2-7bd7267dcd56.png)

Unit tests after the change
![image](https://user-images.githubusercontent.com/5676817/135537073-e45034e6-f00e-4b61-a95c-c357ef6ffdb6.png)
